### PR TITLE
Add 'If-None-Match:' HTTP request header to PUT request

### DIFF
--- a/SimpleCalDAVClient.php
+++ b/SimpleCalDAVClient.php
@@ -193,7 +193,7 @@ class SimpleCalDAVClient
         }
 
         // Put it!
-        $newEtag = $this->client->DoPUTRequest($this->url . $uid . '.ics', $cal);
+        $newEtag = $this->client->DoPUTRequest($this->url . $uid . '.ics', $cal, '*');
 
         // PUT-request successfull?
         if ($this->client->GetHttpResultCode() != '201') {


### PR DESCRIPTION
If the client intends to create a new non-collection resource, such as
a new VEVENT, the client SHOULD use the HTTP request header
"If-None-Match: *" on the PUT request.

The "If-None-Match: *" request header ensures that the client will not
inadvertently overwrite an existing resource if the last path segment
turned out to already be used.